### PR TITLE
Changes to support Query insights for MYSQL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "google_project_service" "cloudsql_api" {
 
 module "google_mysql_db" {
   source                          = "GoogleCloudPlatform/sql-db/google//modules/mysql"
-  version                         = "13.0.0"
+  version                         = "13.0.1"
   depends_on                      = [google_project_service.compute_api, google_project_service.cloudsql_api]
   deletion_protection             = var.deletion_protection_master_instance
   project_id                      = data.google_client_config.google_client.project

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ module "google_mysql_db" {
       availability_type     = var.read_replica_availability_type
       user_labels           = var.labels_read_replica
       encryption_key_name   = null
-      allocated_ip_range    = var.allocated_ip_range
+      allocated_ip_range    = var.read_replica_pvt_ip_range
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -107,8 +107,10 @@ module "google_mysql_db" {
       }
       database_flags      = local.db_flags_read_replica
       disk_autoresize     = var.disk_auto_resize_read_replica
+      disk_autoresize_limit = var.disk_autoresize_limit
       disk_size           = var.disk_size_gb_read_replica
       disk_type           = "PD_SSD"
+      availability_type   = var.read_replica_availability_type
       user_labels         = var.labels_read_replica
       encryption_key_name = null
     }

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "google_project_service" "cloudsql_api" {
 
 module "google_mysql_db" {
   source                          = "GoogleCloudPlatform/sql-db/google//modules/mysql"
-  version                         = "9.0.0"
+  version                         = "13.0.0"
   depends_on                      = [google_project_service.compute_api, google_project_service.cloudsql_api]
   deletion_protection             = var.deletion_protection_master_instance
   project_id                      = data.google_client_config.google_client.project
@@ -77,6 +77,7 @@ module "google_mysql_db" {
     ipv4_enabled        = var.public_access_master_instance
     private_network     = var.private_network
     require_ssl         = null
+    allocated_ip_range  = var.allocated_ip_range
   }
 
   # backup settings
@@ -89,7 +90,11 @@ module "google_mysql_db" {
     retained_backups               = null
     retention_unit                 = null
   }
-
+  insights_config = {
+    query_string_length     = var.insights_config.query_string_length
+    record_application_tags = var.insights_config.record_application_tags
+    record_client_address   = var.insights_config.record_client_address
+  }
   # read replica settings
   read_replica_deletion_protection = var.deletion_protection_read_replica
   read_replica_name_suffix         = local.read_replica_name_suffix

--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,7 @@ module "google_mysql_db" {
         ipv4_enabled        = var.public_access_read_replica
         private_network     = var.private_network
         require_ssl         = null
+        allocated_ip_range  = var.read_replica_pvt_ip_range
       }
       database_flags        = local.db_flags_read_replica
       disk_autoresize       = var.disk_auto_resize_read_replica
@@ -113,7 +114,6 @@ module "google_mysql_db" {
       availability_type     = var.read_replica_availability_type
       user_labels           = var.labels_read_replica
       encryption_key_name   = null
-      allocated_ip_range    = var.read_replica_pvt_ip_range
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ module "google_mysql_db" {
       disk_autoresize_limit = var.disk_autoresize_limit
       disk_size             = var.disk_size_gb_read_replica
       disk_type             = "PD_SSD"
-      availability_type     = var.read_replica_availability_type
+      availability_type     = var.highly_available_read_replica ? "REGIONAL" : "ZONAL"
       user_labels           = var.labels_read_replica
       encryption_key_name   = var.encryption_key_name_read_replica
     }

--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ module "google_mysql_db" {
       availability_type     = var.read_replica_availability_type
       user_labels           = var.labels_read_replica
       encryption_key_name   = null
+      allocated_ip_range    = var.allocated_ip_range
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -91,6 +91,7 @@ module "google_mysql_db" {
     retained_backups               = null
     retention_unit                 = null
   }
+
   # read replica settings
   read_replica_deletion_protection = var.deletion_protection_read_replica
   read_replica_name_suffix         = local.read_replica_name_suffix
@@ -104,11 +105,11 @@ module "google_mysql_db" {
         ipv4_enabled        = var.public_access_read_replica
         private_network     = var.private_network
         require_ssl         = null
-        allocated_ip_range  = var.read_replica_pvt_ip_range
+        allocated_ip_range  = var.allocated_ip_range_read_replica
       }
       database_flags        = local.db_flags_read_replica
       disk_autoresize       = var.disk_auto_resize_read_replica
-      disk_autoresize_limit = var.disk_autoresize_limit
+      disk_autoresize_limit = var.disk_autoresize_limit_read_replica
       disk_size             = var.disk_size_gb_read_replica
       disk_type             = "PD_SSD"
       availability_type     = var.highly_available_read_replica ? "REGIONAL" : "ZONAL"

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,7 @@ module "google_mysql_db" {
   maintenance_window_day          = var.maintenance_window.day_utc
   maintenance_window_hour         = var.maintenance_window.hour_utc
   maintenance_window_update_track = var.maintenance_window.update_track
+  insights_config                 = var.insights_config
   ip_configuration = {
     authorized_networks = local.master_authorized_networks
     ipv4_enabled        = var.public_access_master_instance
@@ -89,11 +90,6 @@ module "google_mysql_db" {
     transaction_log_retention_days = null
     retained_backups               = null
     retention_unit                 = null
-  }
-  insights_config = {
-    query_string_length     = var.insights_config.query_string_length
-    record_application_tags = var.insights_config.record_application_tags
-    record_client_address   = var.insights_config.record_client_address
   }
   # read replica settings
   read_replica_deletion_protection = var.deletion_protection_read_replica

--- a/main.tf
+++ b/main.tf
@@ -105,14 +105,14 @@ module "google_mysql_db" {
         private_network     = var.private_network
         require_ssl         = null
       }
-      database_flags      = local.db_flags_read_replica
-      disk_autoresize     = var.disk_auto_resize_read_replica
+      database_flags        = local.db_flags_read_replica
+      disk_autoresize       = var.disk_auto_resize_read_replica
       disk_autoresize_limit = var.disk_autoresize_limit
-      disk_size           = var.disk_size_gb_read_replica
-      disk_type           = "PD_SSD"
-      availability_type   = var.read_replica_availability_type
-      user_labels         = var.labels_read_replica
-      encryption_key_name = null
+      disk_size             = var.disk_size_gb_read_replica
+      disk_type             = "PD_SSD"
+      availability_type     = var.read_replica_availability_type
+      user_labels           = var.labels_read_replica
+      encryption_key_name   = null
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ module "google_mysql_db" {
       disk_type             = "PD_SSD"
       availability_type     = var.read_replica_availability_type
       user_labels           = var.labels_read_replica
-      encryption_key_name   = null
+      encryption_key_name   = var.encryption_key_name_read_replica
     }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,11 @@ variable "disk_auto_resize_read_replica" {
   type        = bool
   default     = false
 }
-
+variable "disk_autoresize_limit" {
+  description = "Allows users to set a specific limit on how large the storage on their instance can automatically grow. The default value is zero, which means there is no limit and disk size can grow up to the maximum available storage for the instance tier. Applying the automatic disk increase limit does not cause any disruptions to your database workload."
+  type        = number
+  default     = 0
+}
 variable "backup_enabled" {
   description = "Specify whether backups should be enabled for the MySQL instance."
   type        = bool
@@ -138,6 +142,12 @@ variable "highly_available" {
   description = "Whether the MySQL instance should be highly available (REGIONAL) or single zone. Highly Available (HA) instances will automatically failover to another zone within the region if there is an outage of the primary zone. HA instances are recommended for production use-cases and increase cost. Value of 'true' requires 'var.pit_recovery_enabled' to be 'true'."
   type        = bool
   default     = false
+}
+
+variable "read_replica_availability_type" {
+  description = "Set the availability type of their read replicas as ZONAL or REGIONAL"
+  type        = string
+  default     = "ZONAL"
 }
 
 variable "read_replica_count" {

--- a/variables.tf
+++ b/variables.tf
@@ -218,9 +218,9 @@ variable "public_access_master_instance" {
 
 variable "allocated_ip_range" {
   description = <<-EOT
-  The name of the allocated ip range for the private ip CloudSQL instance. 
-  If already available this can be derived from VPC -> Private Service Connection -> Name of the allocated range
-  For example: "google-managed-services-default". If set, the instance ip will be created in the allocated range. 
+  The name of the allocated IP range for the private IP of the CloudSQL instance. 
+  If already available this can be derived from VPC -> Private Service Connection -> Name of the allocated range. For example: "google-managed-services-default".
+  If set, the IP will be created within the allocated IP range. 
   The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression a-z?. 
   If set, a CIDR range of /20 is advised.
   EOT

--- a/variables.tf
+++ b/variables.tf
@@ -144,10 +144,10 @@ variable "highly_available" {
   default     = false
 }
 
-variable "read_replica_availability_type" {
-  description = "Set the availability type of their read replicas as ZONAL or REGIONAL"
-  type        = string
-  default     = "ZONAL"
+variable "highly_available_read_replica" {
+  description = "Whether the MySQL instance should be highly available REGIONAL or ZONAL. Highly Available (HA) instances will automatically failover to another zone within the region if there is an outage of the primary zone. HA instances are recommended for production use-cases and increase cost"
+  type        = bool
+  default     = false
 }
 
 variable "read_replica_count" {

--- a/variables.tf
+++ b/variables.tf
@@ -115,8 +115,8 @@ variable "disk_auto_resize_read_replica" {
   type        = bool
   default     = false
 }
-variable "disk_autoresize_limit" {
-  description = "Allows users to set a specific limit on how large the storage on their instance can automatically grow. The default value is zero, which means there is no limit and disk size can grow up to the maximum available storage for the instance tier. Applying the automatic disk increase limit does not cause any disruptions to your database workload."
+variable "disk_autoresize_limit_read_replica" {
+  description = "Allows users to set a specific limit on how large the storage on their instance can automatically grow up to. The default value is zero, which means there is no limit and disk size can grow up to the maximum available storage for the instance tier. Applying the automatic disk increase limit does not cause any disruptions to your database workload."
   type        = number
   default     = 0
 }
@@ -145,7 +145,7 @@ variable "highly_available" {
 }
 
 variable "highly_available_read_replica" {
-  description = "Whether the MySQL instance should be highly available REGIONAL or ZONAL. Highly Available (HA) instances will automatically failover to another zone within the region if there is an outage of the primary zone. HA instances are recommended for production use-cases and increase cost"
+  description = "Whether the MySQL instance should be highly available (REGIONAL) or not (ZONAL). Highly Available (HA) instances will automatically failover to another zone within the region if there is an outage of the primary zone. HA instances are recommended for production use-cases and, therefore, increase cost"
   type        = bool
   default     = false
 }
@@ -156,8 +156,14 @@ variable "read_replica_count" {
   default     = 0
 }
 
-variable "read_replica_pvt_ip_range" {
-  description = "The name of the allocated ip range for the private ip CloudSQL instance. For example: google-managed-services-default. If set, the instance ip will be created in the allocated range. The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression a-z?"
+variable "allocated_ip_range_read_replica" {
+  description = <<-EOT
+  The name of the allocated ip range for the private ip CloudSQL instance. 
+  If already available this can be derived from VPC -> Private Service Connection -> Name of the allocated range
+  For example: "google-managed-services-default". If set, the instance ip will be created in the allocated range. 
+  The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression a-z?. 
+  If set, a CIDR range of /20 is advised.
+  EOT
   type        = string
   default     = null
 }
@@ -213,6 +219,7 @@ variable "public_access_master_instance" {
 variable "allocated_ip_range" {
   description = <<-EOT
   The name of the allocated ip range for the private ip CloudSQL instance. 
+  If already available this can be derived from VPC -> Private Service Connection -> Name of the allocated range
   For example: "google-managed-services-default". If set, the instance ip will be created in the allocated range. 
   The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression a-z?. 
   If set, a CIDR range of /20 is advised.
@@ -289,6 +296,7 @@ variable "encryption_key_name_read_replica" {
   type        = string
   default     = null
 }
+
 variable "additional_databases" {
   description = "A list of additional databases to be created in the CloudSQL instance"
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -195,10 +195,11 @@ variable "public_access_master_instance" {
 }
 
 variable "allocated_ip_range" {
-  description = "For MYSQL db, adding this property to Cloud SQL modules will allow users to select a specific allocated range for their private instances."
+  description = "Allow users to select a specific IP range for their private instances"
   type        = string
   default     = null
 }
+
 variable "public_access_read_replica" {
   description = "Whether public IPv4 address should be assigned to the MySQL read-replica instance(s). If set to 'false' then 'var.private_network' must be defined."
   type        = bool
@@ -292,10 +293,6 @@ variable "maintenance_window" {
   }
 }
 
-# ----------------------------------------------------------------------------------------------------------------------
-# To enable Query Insights
-# ----------------------------------------------------------------------------------------------------------------------
-
 variable "insights_config" {
   description = "The insights_config settings for the database."
   type = object({
@@ -303,9 +300,5 @@ variable "insights_config" {
     record_application_tags = bool
     record_client_address   = bool
   })
-  default = {
-    query_string_length     = 1024
-    record_application_tags = false
-    record_client_address   = false
-  }
+  default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -194,6 +194,11 @@ variable "public_access_master_instance" {
   default     = false
 }
 
+variable "allocated_ip_range" {
+  description = "For MYSQL db, adding this property to Cloud SQL modules will allow users to select a specific allocated range for their private instances."
+  type        = string
+  default     = null
+}
 variable "public_access_read_replica" {
   description = "Whether public IPv4 address should be assigned to the MySQL read-replica instance(s). If set to 'false' then 'var.private_network' must be defined."
   type        = bool
@@ -284,5 +289,23 @@ variable "maintenance_window" {
     day_utc      = 1
     hour_utc     = 19
     update_track = "stable"
+  }
+}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# To enable Query Insights
+# ----------------------------------------------------------------------------------------------------------------------
+
+variable "insights_config" {
+  description = "The insights_config settings for the database."
+  type = object({
+    query_string_length     = number
+    record_application_tags = bool
+    record_client_address   = bool
+  })
+  default = {
+    query_string_length     = 1024
+    record_application_tags = false
+    record_client_address   = false
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -211,7 +211,7 @@ variable "public_access_master_instance" {
 }
 
 variable "allocated_ip_range" {
-  description = "Allow users to select a specific IP range for their private instances"
+  description = "Allow users to select a specific IP range for their private instances. private_g_services: A CIDR range (/20 advised) for Google services producers (like CloudSQL, Firebase, etc) in private subnet of the VPC. See https://cloud.google.com/vpc/docs/configure-private-services-access#allocating-range. See https://cloud.google.com/sql/docs/mysql/configure-private-services-access#configure-access."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -158,9 +158,9 @@ variable "read_replica_count" {
 
 variable "allocated_ip_range_read_replica" {
   description = <<-EOT
-  The name of the allocated ip range for the private ip CloudSQL read replica instance. 
-  If already available this can be derived from VPC -> Private Service Connection -> Name of the allocated range
-  For example: "google-managed-services-default". If set, the instance ip will be created in the allocated range. 
+  The name of the allocated IP range for the private IP of read replicas of the CloudSQL instance. 
+  If already available this can be derived from VPC -> Private Service Connection -> Name of the allocated range. For example: "google-managed-services-default".
+  If set, the IP will be created within the allocated IP range. 
   The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression a-z?. 
   If set, a CIDR range of /20 is advised.
   EOT

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,12 @@ variable "read_replica_count" {
   default     = 0
 }
 
+variable "read_replica_pvt_ip_range" {
+  description = "The name of the allocated ip range for the private ip CloudSQL instance. For example: google-managed-services-default. If set, the instance ip will be created in the allocated range. The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression a-z?"
+  type        = string
+  default     = null
+}
+
 variable "authorized_networks_master_instance" {
   description = "External networks that can access the MySQL master instance through HTTPS."
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -279,7 +279,11 @@ variable "additional_users" {
   }))
   default = []
 }
-
+variable "encryption_key_name_read_replica" {
+  description = "Encryption key is required for replicas in different regions. For replicas in same region as master, set encryption_key_name = null"
+  type        = string
+  default     = null
+}
 variable "additional_databases" {
   description = "A list of additional databases to be created in the CloudSQL instance"
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -211,7 +211,12 @@ variable "public_access_master_instance" {
 }
 
 variable "allocated_ip_range" {
-  description = "Allow users to select a specific IP range for their private instances. private_g_services: A CIDR range (/20 advised) for Google services producers (like CloudSQL, Firebase, etc) in private subnet of the VPC. See https://cloud.google.com/vpc/docs/configure-private-services-access#allocating-range. See https://cloud.google.com/sql/docs/mysql/configure-private-services-access#configure-access."
+  description = <<-EOT
+  The name of the allocated ip range for the private ip CloudSQL instance. 
+  For example: "google-managed-services-default". If set, the instance ip will be created in the allocated range. 
+  The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression a-z?. 
+  If set, a CIDR range of /20 is advised.
+  EOT
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -158,7 +158,7 @@ variable "read_replica_count" {
 
 variable "allocated_ip_range_read_replica" {
   description = <<-EOT
-  The name of the allocated ip range for the private ip CloudSQL instance. 
+  The name of the allocated ip range for the private ip CloudSQL read replica instance. 
   If already available this can be derived from VPC -> Private Service Connection -> Name of the allocated range
   For example: "google-managed-services-default". If set, the instance ip will be created in the allocated range. 
   The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression a-z?. 


### PR DESCRIPTION
Upgraded "GoogleCloudPlatform/sql-db/google//modules/mysql" module version to from 9.0.0 to 13.0.0 to support Query insights for MYSQL
After version 10.0.0 allocated_ip_range must now be specified for instances. Added allocated_ip_range = null variable